### PR TITLE
#47 adding option to filter chromosomes

### DIFF
--- a/bin/cager_bigwig.R
+++ b/bin/cager_bigwig.R
@@ -2,7 +2,7 @@
 #'
 #' @param bsgenome_name the name of the reference genome (bsgenome)
 #' @param bigwig_paths list of input bigwig files with full path
-#' @param sample_names list of sample names
+#' @param chromosome_names list of chromosome names to keep
 #' @param cpus number of cores to use
 #' @return a CAGEexp object
 #' @examples
@@ -14,6 +14,7 @@
 read_in_bigwig <- function(
     bsgenome_name,
     bigwig_paths,
+    chromosome_names,
     cpus){
 
   bigwig_paths <- stringr::str_squish(bigwig_paths)
@@ -30,9 +31,17 @@ read_in_bigwig <- function(
 
   names(signals) = basename(bigwigs)
 
+  signals_chr_filt <- list()
+  for (sname in names(signals)){
+    signal <- signals[[sname]]
+    signal <- signal[seqnames(signal) %in% chromosome_names]
+    signals_chr_filt[[sname]] <- signal
+  }
+  
+
   signalsSplit = split(
-    signals,
-    grepl("str1", names(signals)))
+    signals_chr_filt,
+    grepl("str1", names(signals_chr_filt)))
 
   plus = lapply(signalsSplit$`TRUE`, function(x) {
     strand(x) = "+"

--- a/bin/cager_clustering.R
+++ b/bin/cager_clustering.R
@@ -2,12 +2,16 @@
 #'
 #' @param ce normalized CAGEexp object
 #' @param iqw_plot_lim Limits to IQ width plot x axis
+#' @param sample_num_thr Threshold for nr of samples where tpm should be higher
+#' @param ctss_thr Tpm threshold
 #' @param num_core Number of cores to run on
 #' @return ce clustered CAGEexp object
 #' @examples
 #' cager_clustering(
 #' ce,
 #' iqw_plot_lim = c(0, 150),
+#' sample_num_thr = 1,
+#' ctss_thr = 1,
 #' num_core = 4)
 
 cager_clustering <- function(ce, iqw_plot_lim, sample_num_thr, ctss_thr, num_core){

--- a/bin/cager_modified_plots.R
+++ b/bin/cager_modified_plots.R
@@ -275,7 +275,8 @@ plotCorrelation2_local <- function( expr.table, samples, method
   }
   
   if (plot_pairs){
-    pairs_plot <- pairs( expr.table
+    pdf("correlations_heatmap_plot.pdf")
+    pairs( expr.table
            , lower.panel = pointsUnique
            , upper.panel = panel.cor
            , pch = "."
@@ -285,8 +286,7 @@ plotCorrelation2_local <- function( expr.table, samples, method
            , xaxp = c(1,10,1)
            , yaxp = c(1,10,1)
            , labels = samples)
-    pdf("correlations_heatmap_plot.pdf")
-    print(pairs_plot)
+    pairs_plot <- recordPlot()
     dev.off()
     saveRDS(pairs_plot, "correlations_heatmap_plot.rds")
   }

--- a/bin/cager_normalization.R
+++ b/bin/cager_normalization.R
@@ -9,8 +9,8 @@
 #' @examples
 #' cager_normalization(
 #' ce,
-#' rangeMin=50,
-#' rangeMax=100000,
+#' rangeMin=10,
+#' rangeMax=10000,
 #' method="powerLaw",
 #' total_tag_num=1*10^6)
 
@@ -23,7 +23,7 @@ cager_normalization <- function(
     outlist <- calculateReverseCumulative(
         object = ce,
         values = "raw",
-        fitInRange = c(10, 1000))
+        fitInRange = c(rangeMin, rangeMax))
     tag_count_df <- outlist[[1]]
     slope <- outlist[[2]]
     library_size <- outlist[[3]]
@@ -36,7 +36,7 @@ cager_normalization <- function(
         intercept=intercept,
         library_size=library_size,
         fit.slopes = fit.slopes,
-        fitInRange = c(range_min, range_max))
+        fitInRange = c(rangeMin, rangeMax))
     
     save_plot(
         "reverse_cumulative_plot.pdf",
@@ -45,8 +45,8 @@ cager_normalization <- function(
     ce <- CAGEr::normalizeTagCount(
         ce,
         method = method,
-        fitInRange = c(range_min, range_max),
-        alpha = slope,
+        fitInRange = c(rangeMin, rangeMax),
+        alpha = -slope,
         T = total_tag_num)
 
     return(ce)

--- a/bin/cager_preprocessing.R
+++ b/bin/cager_preprocessing.R
@@ -9,6 +9,7 @@ required.libraries <- c(
     "optparse",
     "rlang",
     "CAGEr",
+    "GenomicFeatures",
     "dplyr",
     "purrr",
     "magrittr",
@@ -75,11 +76,6 @@ option_list = list(
         default = NULL,
         help = "SQLite file with a TxDb genome annotation package (Mandatory)"),
     make_option(
-        c("-k", "--pca_rank"),
-        type = "integer",
-        default = 50,
-        help = "Rank of PCAs for analysis. (Default = 50) "),
-    make_option(
         c("-p", "--project_dir"),
         type = "character",
         default = 0,
@@ -112,7 +108,6 @@ ctss_thr            <- opt$ctss_thr
 consensus_ctss_thr  <- opt$consensus_ctss_thr
 consensus_ctss_dist <- opt$consensus_ctss_dist
 tx_annotation       <- opt$annotation
-pca_rank             <- opt$pca_rank
 project_dir         <- opt$project_dir
 bsgenome            <- opt$bsgenome
 num_core            <- opt$num_core

--- a/bin/cager_readin.R
+++ b/bin/cager_readin.R
@@ -39,10 +39,15 @@ option_list = list(
         default = NULL,
         help = "Name of the BSgenome version to be used (Mandatory)"),
     make_option(
+        c("-n", "--chromosomes"),
+        type = "character",
+        default = NULL,
+        help = "Comma separated list of chromosomes to keep (Optional)"),
+    make_option(
         c("-p", "--project_dir"),
         type = "character",
-        default = 0,
-        help = "Project directory, from which the analysis is run."),
+        default = NULL,
+        help = "Project directory, from which the analysis is run. (Mandatory)"),
     make_option(
         c("-c", "--num_core"),
         type = "integer",
@@ -58,6 +63,7 @@ opt = optparse::parse_args(opt_parser)
 data_type           <- opt$data_type
 sample_table_list   <- opt$sample_table_list
 bsgenome            <- opt$bsgenome
+chromosome_names    <- opt$chromosomes
 project_dir         <- opt$project_dir
 num_core            <- opt$num_core
 
@@ -96,9 +102,11 @@ if (tolower(data_type) == "bam"){
         cpus=num_core
     )
 }else if(tolower(data_type) == "bigwig") {
+    chromosome_names_list <- unlist(strsplit(chromosome_names, ','))
     ce <- read_in_bigwig(
         bsgenome_name=reference_name,
         bigwig_paths=sample_table$path,
+        chromosome_names=chromosome_names_list,
         cpus=num_core
     )
 } else {

--- a/bin/cager_tag_qc.R
+++ b/bin/cager_tag_qc.R
@@ -89,9 +89,6 @@ if (length(sampleLabels(ce)) > 10){
         digits = 3,
         plot_pairs = FALSE)
 
-    # save intermediate file
-    saveRDS(corr_m, "corr_m.rds")
-
     # plot correlations in heatmap format
     hm <- gplots::heatmap.2(corr_m, trace="none", margins=c(12, 12),cexRow=0.2)
     pdf("correlations_heatmap_plot.pdf")
@@ -107,10 +104,10 @@ if (length(sampleLabels(ce)) > 10){
         method = "pearson",
         digits = 3,
         plot_pairs=TRUE)
-    # save intermediate file
-    saveRDS(corr_m, "corr_m.rds")
 }
 
+# save intermediate file
+saveRDS(corr_m, "corr_m.rds")
 
 # Plot sequence distribution at the TSS
 # tsslogo_plot <- CAGEr::TSSlogo(

--- a/bin/cager_tagcluster_qc.R
+++ b/bin/cager_tagcluster_qc.R
@@ -49,13 +49,12 @@ option_list = list(
         c("-t", "--tpm_threshold"),
         type = "double",
         default = 1,
-        help = "Threshold to filter CTSS that has few tags per million (Optional), defaults to 1 ",
-        metavar = "double")
+        help = "Threshold to filter CTSS that has few tags per million (Optional), defaults to 1 "),
     make_option(
         c("-k", "--pca_rank"),
         type = "integer",
         default = 50,
-        help = "Rank of PCAs for analysis. (Default = 50) "),
+        help = "Rank of PCAs for analysis. (Default = 50) ")
 )
 
 message("; Reading arguments from command line.")

--- a/bin/cager_tagcluster_qc.R
+++ b/bin/cager_tagcluster_qc.R
@@ -51,6 +51,11 @@ option_list = list(
         default = 1,
         help = "Threshold to filter CTSS that has few tags per million (Optional), defaults to 1 ",
         metavar = "double")
+    make_option(
+        c("-k", "--pca_rank"),
+        type = "integer",
+        default = 50,
+        help = "Rank of PCAs for analysis. (Default = 50) "),
 )
 
 message("; Reading arguments from command line.")
@@ -63,9 +68,8 @@ ce_path         <- opt$cageexp_object
 tx_annotation   <- opt$annotation
 bsgenome        <- opt$bsgenome
 project_dir     <- opt$project_dir
-tpmThreshold  <- opt$tpm_threshold
-pdfWidth      <- opt$pdf_width
-pdfHeight     <- opt$pdf_height
+tpmThreshold    <- opt$tpm_threshold
+pca_rank        <- opt$pca_rank
 
 # installing BSgenome
 source(file.path(project_dir, "bin/install_bsgenome.R"))

--- a/bin/cager_tagcluster_qc.R
+++ b/bin/cager_tagcluster_qc.R
@@ -141,4 +141,4 @@ save_plot(
 
 # Consensus clustered CTSS quality plots
 # uses functions from plot_number_and_pca_of_ctss.R
-consensus_qc(ce=ce, pcarank=pca_rank)
+# consensus_qc(ce=ce, pcarank=pca_rank)

--- a/modules/local/cager_preprocessing.nf
+++ b/modules/local/cager_preprocessing.nf
@@ -10,6 +10,7 @@ process CAGER_PREPROCESSING {
     path cager_obj
     path bsgenome_file
     val bsgenome_name
+    path txdb
 
     output:
     path "normalized_clustered_cagexp.rds",        emit: rds
@@ -32,6 +33,9 @@ process CAGER_PREPROCESSING {
         -t ${params.total_tag_num} \
         -s ${params.sample_num_thr} \
         -r ${params.ctss_thr} \
+        -u ${params.consensus_ctss_thr} \
+        -d ${params.consensus_ctss_dist} \
+        -a ${txdb} \
         -p ${projectDir} \
         -b \${bsgenome} \
         -c ${task.cpus}

--- a/modules/local/cager_readin.nf
+++ b/modules/local/cager_readin.nf
@@ -26,6 +26,7 @@ process CAGER_READIN {
         -t "${data_type}" \
         -b \${bsgenome} \
         -s "${sample_table}" \
+        -n "${params.chromosomes_to_keep}" \
         -p ${projectDir} \
         -c ${task.cpus}
 

--- a/modules/local/cager_tag_qc.nf
+++ b/modules/local/cager_tag_qc.nf
@@ -31,8 +31,6 @@ process CAGER_TAG_QC {
         -a ${txdb} \
         -b \${bsgenome} \
         -p ${projectDir}
-    
-    rm Rplots.pdf
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/cager_tagcluster_qc.nf
+++ b/modules/local/cager_tagcluster_qc.nf
@@ -29,6 +29,7 @@ process CAGER_TAGCLUSTER_QC {
         -a ${txdb} \
         -b \${bsgenome} \
         -p ${projectDir} \
+        -k ${params.pca_rank} \
         -t ${params.tpm_threshold}
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/cager_tagcluster_qc.nf
+++ b/modules/local/cager_tagcluster_qc.nf
@@ -29,8 +29,8 @@ process CAGER_TAGCLUSTER_QC {
         -a ${txdb} \
         -b \${bsgenome} \
         -p ${projectDir} \
-        -k ${params.pca_rank} \
-        -t ${params.tpm_threshold}
+        -t ${params.tpm_threshold} \
+        -k ${params.pca_rank}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/params_only_cager.yaml
+++ b/params_only_cager.yaml
@@ -1,7 +1,7 @@
 # pipeline parameters
-fullpipeline: true
+fullpipeline: false
 maponly: false
-cageronly: false
+cageronly: true
 
 # preprocessing parameters
 samplesheet:
@@ -19,7 +19,7 @@ unique_only: false
 chromosomes_to_keep: "chr1,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr2,chr20,chr21,chr22,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chrM,chrX,chrY"
 
 # CAGEr parameters
-cager_sample_file: # with sorted list of bigwigs, if mapping is run elsewhere
+cager_sample_file: "sample_list.csv" # with sorted list of bigwigs, if mapping is run elsewhere
 # BSgenome
 forgeseed:
 sourcedir:
@@ -34,5 +34,9 @@ total_tag_num: 1000000
 # parameters for CTSS
 sample_num_thr: 1
 ctss_thr: 1
+# parameters for consensus clusters
+consensus_ctss_thr: 5
+consensus_ctss_dist: 100
+pca_rank: 50
 # markdown location
 markdown_path: "assets/cager_report.Rmd"

--- a/params_only_cager.yaml
+++ b/params_only_cager.yaml
@@ -16,6 +16,7 @@ seq_platform: "illumina"
 seq_center: false
 # whether to take the uniquely mapped only
 unique_only: false
+chromosomes_to_keep: "chr1,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr2,chr20,chr21,chr22,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chrM,chrX,chrY"
 
 # CAGEr parameters
 cager_sample_file: # with sorted list of bigwigs, if mapping is run elsewhere

--- a/subworkflows/local/cager_analysis.nf
+++ b/subworkflows/local/cager_analysis.nf
@@ -48,7 +48,7 @@ workflow CAGER {
         tra_ch_tss = CAGER_TAG_QC.out.plots
         corr_data = CAGER_TAG_QC.out.correlation_rds
 
-        CAGER_PREPROCESSING(annotated_cager_rds, ch_bsgenome_file, ch_bsgenome_name)
+        CAGER_PREPROCESSING(annotated_cager_rds, ch_bsgenome_file, ch_bsgenome_name, ch_txdb)
         clustered_cager_rds = CAGER_PREPROCESSING.out.rds
         ch_versions = ch_versions.mix(CAGER_PREPROCESSING.out.versions)
         // reverse cumulative, iterquartile width, ctss counts


### PR DESCRIPTION
Small fix so that the user can provide a comma separated list of chromosomes and only those kept when reading in CAGEr from bigwigs.
Note: not yet implemented for bam, but it also might not be a problem there.
