### PR TITLE
Fastqc fix

### DIFF
--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -15,7 +15,15 @@ top_modules:
   - fastqc:
       name: "FastQC (raw)"
       info: "shows the quality metrics of raw reads."
-  - cutadapt
+      path_filters_exclude:
+        - "*_val_*"
+        - "*_trimmed_*"
   - fastqc:
       name: "FastQC (trimmed)"
       info: "shows the quality metrics of trimmed reads."
+      path_filters:
+        - "*_val_*"
+        - "*_trimmed_*"
+  - cutadapt:
+      name: "Cutadapt"
+      info: "shows the quality metrics of G-trimmed reads."

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -15,11 +15,7 @@ top_modules:
   - fastqc:
       name: "FastQC (raw)"
       info: "shows the quality metrics of raw reads."
-      path_filters_exclude:
-        - "*_val_*"
   - cutadapt
   - fastqc:
       name: "FastQC (trimmed)"
       info: "shows the quality metrics of trimmed reads."
-      path_filters:
-        - "*_val_*"

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -71,7 +71,7 @@ process {
             mode: params.publish_dir_mode
         ]
         container = 'quay.io/biocontainers/trim-galore:0.6.7--hdfd78af_0'
-        ext.args = { "${params.params_trimgalore} --fastqc" } 
+        ext.args = { "${params.params_trimgalore} --fastqc" }
     }
 
     withName: 'CUTADAPT' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -46,6 +46,15 @@ process {
         container = 'quay.io/biocontainers/fastqc:0.11.9--0'
     }
 
+    withName: FASTQC_TRIMMED {
+        ext.args = '--quiet'
+        publishDir = [
+            path: { "${params.outdir}/fastqc_trimmed" },
+            mode: params.publish_dir_mode
+        ]
+        container = 'quay.io/biocontainers/fastqc:0.11.9--0'
+    }
+
     withName: CUSTOM_DUMPSOFTWAREVERSIONS {
         publishDir = [
             path: { "${params.outdir}/pipeline_info" },
@@ -71,7 +80,7 @@ process {
             mode: params.publish_dir_mode
         ]
         container = 'quay.io/biocontainers/trim-galore:0.6.7--hdfd78af_0'
-        ext.args = { "${params.params_trimgalore} --fastqc" }
+        ext.args = { "${params.params_trimgalore}" } //  --fastqc
     }
 
     withName: 'CUTADAPT' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -46,15 +46,6 @@ process {
         container = 'quay.io/biocontainers/fastqc:0.11.9--0'
     }
 
-    withName: FASTQC_TRIMMED {
-        ext.args = '--quiet'
-        publishDir = [
-            path: { "${params.outdir}/fastqc_trimmed" },
-            mode: params.publish_dir_mode
-        ]
-        container = 'quay.io/biocontainers/fastqc:0.11.9--0'
-    }
-
     withName: CUSTOM_DUMPSOFTWAREVERSIONS {
         publishDir = [
             path: { "${params.outdir}/pipeline_info" },
@@ -80,7 +71,7 @@ process {
             mode: params.publish_dir_mode
         ]
         container = 'quay.io/biocontainers/trim-galore:0.6.7--hdfd78af_0'
-        ext.args = { "${params.params_trimgalore}" } //  --fastqc
+        ext.args = { "${params.params_trimgalore} --fastqc" } 
     }
 
     withName: 'CUTADAPT' {

--- a/subworkflows/local/preprocessing.nf
+++ b/subworkflows/local/preprocessing.nf
@@ -4,7 +4,6 @@
 
 include { CAT_FASTQ } from '../../modules/nf-core/cat/fastq/main.nf'
 include { FASTQC } from '../../modules/nf-core/fastqc/main.nf'
-include { FASTQC as FASTQC_TRIMMED } from '../../modules/nf-core/fastqc/main.nf'
 include { READ_REMOVAL } from '../../modules/local/remove_non_g.nf'
 include { TRIMGALORE } from '../../modules/nf-core/trimgalore/main.nf'
 include { CUTADAPT } from '../../modules/nf-core/cutadapt/main.nf'
@@ -41,20 +40,11 @@ workflow PREPROCESSING {
                 TRIMGALORE.out.reads
             )
             ch_versions = ch_versions.mix(CUTADAPT.out.versions)
-
-            FASTQC_TRIMMED (
-                CUTADAPT.out.reads
-            )
-        } else {
-            FASTQC_TRIMMED (
-                TRIMGALORE.out.reads
-            )
         }
 
         ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
         ch_multiqc_files = ch_multiqc_files.mix(TRIMGALORE.out.log.collect{it[1]}.ifEmpty([]))
         ch_multiqc_files = ch_multiqc_files.mix(TRIMGALORE.out.zip.collect{it[1]}.ifEmpty([]))
-        ch_multiqc_files = ch_multiqc_files.mix(FASTQC_TRIMMED.out.zip.collect{it[1]}.ifEmpty([]))
         ch_reads_to_align = !params.nogtrim ? CUTADAPT.out.reads : TRIMGALORE.out.reads
 
     emit:

--- a/subworkflows/local/preprocessing.nf
+++ b/subworkflows/local/preprocessing.nf
@@ -4,7 +4,7 @@
 
 include { CAT_FASTQ } from '../../modules/nf-core/cat/fastq/main.nf'
 include { FASTQC } from '../../modules/nf-core/fastqc/main.nf'
-include { FASTQC_TRIMMED } from '../../modules/nf-core/fastqc/main.nf'
+include { FASTQC as FASTQC_TRIMMED } from '../../modules/nf-core/fastqc/main.nf'
 include { READ_REMOVAL } from '../../modules/local/remove_non_g.nf'
 include { TRIMGALORE } from '../../modules/nf-core/trimgalore/main.nf'
 include { CUTADAPT } from '../../modules/nf-core/cutadapt/main.nf'

--- a/subworkflows/local/preprocessing.nf
+++ b/subworkflows/local/preprocessing.nf
@@ -4,6 +4,7 @@
 
 include { CAT_FASTQ } from '../../modules/nf-core/cat/fastq/main.nf'
 include { FASTQC } from '../../modules/nf-core/fastqc/main.nf'
+include { FASTQC_TRIMMED } from '../../modules/nf-core/fastqc/main.nf'
 include { READ_REMOVAL } from '../../modules/local/remove_non_g.nf'
 include { TRIMGALORE } from '../../modules/nf-core/trimgalore/main.nf'
 include { CUTADAPT } from '../../modules/nf-core/cutadapt/main.nf'
@@ -40,13 +41,21 @@ workflow PREPROCESSING {
                 TRIMGALORE.out.reads
             )
             ch_versions = ch_versions.mix(CUTADAPT.out.versions)
+
+            FASTQC_TRIMMED (
+                CUTADAPT.out.reads
+            )
+        } else {
+            FASTQC_TRIMMED (
+                TRIMGALORE.out.reads
+            )
         }
 
         ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
         ch_multiqc_files = ch_multiqc_files.mix(TRIMGALORE.out.log.collect{it[1]}.ifEmpty([]))
         ch_multiqc_files = ch_multiqc_files.mix(TRIMGALORE.out.zip.collect{it[1]}.ifEmpty([]))
+        ch_multiqc_files = ch_multiqc_files.mix(FASTQC_TRIMMED.out.zip.collect{it[1]}.ifEmpty([]))
         ch_reads_to_align = !params.nogtrim ? CUTADAPT.out.reads : TRIMGALORE.out.reads
-
 
     emit:
         ch_reads_to_align

--- a/testdata/params_danio_nepal_test.yaml
+++ b/testdata/params_danio_nepal_test.yaml
@@ -1,6 +1,6 @@
 # pipeline parameters
-fullpipeline: true
-maponly: false
+fullpipeline: false
+maponly: true
 cageronly: false
 gtf: "cageflow_test_data/danRer11_genome/danRer11.ensGene.gtf"
 

--- a/testdata/params_yeast_borlin_test.yaml
+++ b/testdata/params_yeast_borlin_test.yaml
@@ -5,7 +5,7 @@ cageronly: false
 gtf: "cageflow_test_data/sacCer3_genome/sacCer3.ensGene.gtf"
 
 # preprocessing parameters
-samplesheet: "testdata/samplesheet_yeast_borlin_2018_se_test.csv"
+samplesheet: "customcageq/testdata/samplesheet_yeast_borlin_2018_se_test.csv"
 infolder: 
 sample_name_fields: 2
 genome_name: "sacCer3"


### PR DESCRIPTION
Fixing issue 88.
The problem was that in multiqc_config.yml the FastQC report on trimmed reads was added to the overall MultiQC report only if the reads were paired-end. I added a report file name filter for the case of single-end reads too.